### PR TITLE
feat: subscription v2 - pending_schedule flow, trial sessions, daily …

### DIFF
--- a/alembic/versions/307c1eed5b0c_add_schedule_confirmed_and_trial_fields.py
+++ b/alembic/versions/307c1eed5b0c_add_schedule_confirmed_and_trial_fields.py
@@ -1,0 +1,32 @@
+"""add_schedule_confirmed_and_trial_fields
+
+Revision ID: 307c1eed5b0c
+Revises: 82747771ed7b
+Create Date: 2026-04-06 15:00:34.895710
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '307c1eed5b0c'
+down_revision: Union[str, None] = '82747771ed7b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('student_subscriptions', sa.Column('schedule_confirmed_at', sa.DateTime(timezone=True), nullable=True))
+    op.add_column('students', sa.Column('trial_used_at', sa.DateTime(), nullable=True))
+    op.add_column('students', sa.Column('trial_real_training_student_id', sa.Integer(), nullable=True))
+    op.create_foreign_key('fk_students_trial_rts', 'students', 'real_training_students', ['trial_real_training_student_id'], ['id'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('fk_students_trial_rts', 'students', type_='foreignkey')
+    op.drop_column('students', 'trial_real_training_student_id')
+    op.drop_column('students', 'trial_used_at')
+    op.drop_column('student_subscriptions', 'schedule_confirmed_at')

--- a/app/config.py
+++ b/app/config.py
@@ -20,7 +20,7 @@ class Config(BaseSettings):
     GOOGLE_DISCOVERY_URL: str = os.getenv("GOOGLE_DISCOVERY_URL", "")
     CRON_API_KEY: str = os.getenv("CRON_API_KEY", "test-cron-api-key-12345")
 
-    model_config = ConfigDict(env_file=os.getenv("ENV_FILE", ".env"))
+    model_config = ConfigDict(env_file=os.getenv("ENV_FILE", ".envdev"))
 
     @property
     def SQLALCHEMY_DATABASE_URI(self) -> str:

--- a/app/crud/subscription_v2.py
+++ b/app/crud/subscription_v2.py
@@ -49,7 +49,7 @@ def get_active_or_pending_subscription(
 ) -> Optional[StudentSubscription]:
     """Возвращает активный или pending абонемент, чей диапазон покрывает training_date.
 
-    Frozen абонементы исключаются.
+    Frozen и pending_schedule абонементы исключаются.
     """
     return (
         db.query(StudentSubscription)
@@ -58,6 +58,8 @@ def get_active_or_pending_subscription(
                 StudentSubscription.student_id == student_id,
                 func.date(StudentSubscription.start_date) <= training_date,
                 func.date(StudentSubscription.end_date) >= training_date,
+                # Только подтверждённые (не pending_schedule)
+                StudentSubscription.schedule_confirmed_at.isnot(None),
                 # Исключаем замороженные
                 ~(
                     and_(
@@ -83,7 +85,7 @@ def count_subscription_only_visits(
     week_start: date,
     week_end: date,
 ) -> int:
-    """Считает записи студента на is_subscription_only тренировки за Пн-Вс неделю.
+    """Считает ВСЕ записи студента на is_subscription_only тренировки за Пн-Вс неделю.
 
     Исключает статус CANCELLED_SAFE (слот освобождён).
     Считает: PRESENT, ABSENT, CANCELLED_PENALTY, REGISTERED и все прочие.
@@ -192,3 +194,55 @@ def excuse_missed_session(
     missed.makeup_deadline_date = makeup_deadline_date
     db.flush()
     return missed
+
+
+# ---------------------------------------------------------------------------
+# Helpers for schedule confirmation trigger
+# ---------------------------------------------------------------------------
+
+def get_pending_schedule_subscription(
+    db: Session,
+    student_id: int,
+) -> Optional[StudentSubscription]:
+    """Возвращает абонемент студента в статусе PENDING_SCHEDULE (schedule_confirmed_at IS NULL)."""
+    return (
+        db.query(StudentSubscription)
+        .filter(
+            StudentSubscription.student_id == student_id,
+            StudentSubscription.schedule_confirmed_at.is_(None),
+        )
+        .first()
+    )
+
+
+def count_student_active_templates(
+    db: Session,
+    student_id: int,
+) -> int:
+    """Считает количество активных (не замороженных) TrainingStudentTemplate студента."""
+    from app.models.training_template import TrainingStudentTemplate
+    return (
+        db.query(func.count(TrainingStudentTemplate.id))
+        .filter(
+            TrainingStudentTemplate.student_id == student_id,
+            TrainingStudentTemplate.is_frozen == False,
+        )
+        .scalar()
+    ) or 0
+
+
+def get_student_template_ids(
+    db: Session,
+    student_id: int,
+) -> list[int]:
+    """Возвращает список training_template_id для всех активных шаблонов студента."""
+    from app.models.training_template import TrainingStudentTemplate
+    rows = (
+        db.query(TrainingStudentTemplate.training_template_id)
+        .filter(
+            TrainingStudentTemplate.student_id == student_id,
+            TrainingStudentTemplate.is_frozen == False,
+        )
+        .all()
+    )
+    return [r[0] for r in rows]

--- a/app/crud/training_template.py
+++ b/app/crud/training_template.py
@@ -155,6 +155,12 @@ def create_training_student_template(db: Session, student_template_data: Trainin
         is_frozen=False
     )
     db.add(db_student_template)
+    db.flush()
+    db.refresh(db_student_template)
+
+    # Триггер: проверяем не надо ли активировать PENDING_SCHEDULE абонемент
+    _check_and_confirm_schedule(db, student_template_data.student_id)
+
     db.commit()
     db.refresh(db_student_template)
     return db_student_template
@@ -184,3 +190,45 @@ def delete_training_student_template(db: Session, student_template_id: int):
     db.delete(db_student_template)
     db.commit()
     return db_student_template
+
+
+# ---------------------------------------------------------------------------
+# Внутренний хелпер: триггер подтверждения расписания
+# ---------------------------------------------------------------------------
+
+def _check_and_confirm_schedule(db: Session, student_id: int) -> None:
+    """Проверяет, готово ли расписание студента для активации PENDING_SCHEDULE абонемента.
+
+    Срабатывает только если:
+    - у студента есть абонемент в статусе PENDING_SCHEDULE
+    - count(активных шаблонов) >= sessions_per_week
+    """
+    import logging
+    from app.crud.subscription_v2 import (
+        get_pending_schedule_subscription,
+        count_student_active_templates,
+        get_student_template_ids,
+    )
+    from app.services.subscription_v2 import confirm_schedule_and_create_invoice
+
+    logger = logging.getLogger(__name__)
+
+    pending_sub = get_pending_schedule_subscription(db, student_id)
+    if not pending_sub:
+        return
+
+    sessions_per_week = pending_sub.subscription.sessions_per_week or 1
+    template_count = count_student_active_templates(db, student_id)
+
+    if template_count >= sessions_per_week:
+        template_ids = get_student_template_ids(db, student_id)
+        try:
+            confirm_schedule_and_create_invoice(db, pending_sub.id, template_ids)
+            logger.info(
+                f"Schedule confirmed for student {student_id}, "
+                f"subscription {pending_sub.id} activated"
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to confirm schedule for student {student_id}: {e}"
+            )

--- a/app/endpoints/cron_v2.py
+++ b/app/endpoints/cron_v2.py
@@ -1,8 +1,9 @@
 """Cron-эндпоинты v2, защищены X-API-Key."""
 import logging
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
+from typing import Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.core.security import verify_api_key
@@ -35,9 +36,24 @@ def auto_renewal_v2_endpoint(db: Session = Depends(get_db)):
 
 @router.post("/process-daily-operations", dependencies=[Depends(verify_api_key)])
 def process_daily_operations_v2_endpoint(db: Session = Depends(get_db)):
-    """Обрабатывает is_subscription_only тренировки текущего дня (создание MissedSession).
+    """Обрабатывает тренировки вчерашнего дня:
+    - is_subscription_only=True → создаёт MissedSession.
+    - is_subscription_only=False → переводит PENDING инвойсы в UNPAID/CANCELLED.
     Запускается ежедневно в 01:00.
     """
     service = DailyOperationsServiceV2(db)
     result = service.process_daily_operations_v2()
+    return {**result, "timestamp": datetime.now(timezone.utc).isoformat()}
+
+
+@router.post("/backfill-pending-invoices", dependencies=[Depends(verify_api_key)])
+def backfill_pending_invoices_endpoint(
+    before_date: Optional[date] = Query(None, description="Обработать инвойсы до этой даты (не включая). По умолчанию — сегодня."),
+    db: Session = Depends(get_db),
+):
+    """Одноразовый бэкфилл: переводит PENDING TRAINING инвойсы для прошедших тренировок в UNPAID/CANCELLED.
+    Идемпотентен — безопасно запускать повторно.
+    """
+    service = DailyOperationsServiceV2(db)
+    result = service.backfill_pending_invoices(before_date=before_date)
     return {**result, "timestamp": datetime.now(timezone.utc).isoformat()}

--- a/app/endpoints/training_student_template.py
+++ b/app/endpoints/training_student_template.py
@@ -8,6 +8,7 @@ from app.schemas.training_template import (
     TrainingStudentTemplateUpdate,
     TrainingStudentTemplateResponse,
 )
+from app.schemas.subscription_v2 import TemplateAddStudentResponse
 from app.crud.training_template import (
     get_training_student_templates,
     get_training_student_template_by_id,
@@ -15,6 +16,7 @@ from app.crud.training_template import (
     update_training_student_template,
     delete_training_student_template,
 )
+from app.crud.subscription_v2 import get_pending_schedule_subscription, count_student_active_templates
 
 router = APIRouter(prefix="/training_student_templates", tags=["Training Student Templates"])
 
@@ -42,13 +44,39 @@ def read_training_student_template(
 
 
 # Создание нового студент-шаблона
-@router.post("/", response_model=TrainingStudentTemplateResponse)
+@router.post("/", response_model=TemplateAddStudentResponse)
 def create_training_student_template_endpoint(
     training_student_template: TrainingStudentTemplateCreate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user(["ADMIN", "OWNER"]))
 ):
-    return create_training_student_template(db=db, student_template_data=training_student_template)
+    student_id = training_student_template.student_id
+
+    # Запоминаем состояние до добавления
+    pending_sub_before = get_pending_schedule_subscription(db, student_id)
+
+    result = create_training_student_template(db=db, student_template_data=training_student_template)
+
+    # Проверяем активировался ли абонемент
+    subscription_activated = False
+    sessions_left_to_add = None
+    if pending_sub_before:
+        # Перечитываем — если schedule_confirmed_at появился, значит триггер сработал
+        db.refresh(pending_sub_before)
+        subscription_activated = pending_sub_before.schedule_confirmed_at is not None
+        if not subscription_activated:
+            sessions_per_week = pending_sub_before.subscription.sessions_per_week or 1
+            templates_added = count_student_active_templates(db, student_id)
+            sessions_left_to_add = max(0, sessions_per_week - templates_added)
+
+    return TemplateAddStudentResponse(
+        id=result.id,
+        training_template_id=result.training_template_id,
+        student_id=result.student_id,
+        start_date=result.start_date,
+        subscription_activated=subscription_activated,
+        subscription_sessions_left_to_add=sessions_left_to_add,
+    )
 
 
 # Обновление существующего студент-шаблона

--- a/app/models/real_training.py
+++ b/app/models/real_training.py
@@ -65,7 +65,7 @@ class RealTrainingStudent(Base):
 
     # Relationships
     real_training = relationship("RealTraining", back_populates="students")
-    student = relationship("Student", back_populates="real_trainings")
+    student = relationship("Student", foreign_keys=[student_id], back_populates="real_trainings")
     template_student = relationship("TrainingStudentTemplate", back_populates="real_trainings")
     attendance_marked_by = relationship("User", foreign_keys=[attendance_marked_by_id])
     subscription = relationship("StudentSubscription", back_populates="real_trainings") 

--- a/app/models/student.py
+++ b/app/models/student.py
@@ -28,7 +28,11 @@ class Student(Base):
     active_subscription = relationship("Subscription", foreign_keys=[active_subscription_id])
 
     # Связь с реальными тренировками
-    real_trainings = relationship("RealTrainingStudent", back_populates="student")
+    real_trainings = relationship("RealTrainingStudent", foreign_keys="RealTrainingStudent.student_id", back_populates="student")
+
+    # Пробное занятие
+    trial_used_at = Column(DateTime, nullable=True)
+    trial_real_training_student_id = Column(Integer, ForeignKey("real_training_students.id"), nullable=True)
 
     @property
     def has_unpaid_invoice(self) -> bool:

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -43,6 +43,8 @@ class StudentSubscription(Base):
     # v2: дата дедлайна оплаты и флаг пропорциональности (старые поля остаются до Фазы 2)
     payment_due_date = Column(Date, nullable=True)
     is_prorated = Column(Boolean, default=False)
+    # v2: NULL = PENDING_SCHEDULE (расписание ещё не настроено), NOT NULL = активирован
+    schedule_confirmed_at = Column(DateTime(timezone=True), nullable=True)
 
     # Автопродление
     auto_renewal_invoice_id = Column(Integer, ForeignKey("invoices.id"), nullable=True)  # Инвойс на автопродление
@@ -57,7 +59,11 @@ class StudentSubscription(Base):
     def status(self):
         """Вычисляет статус абонемента с учетом временных зон"""
         current_time = datetime.now(timezone.utc)  # Используем timezone-aware datetime
-        
+
+        # v2: расписание ещё не настроено
+        if self.schedule_confirmed_at is None:
+            return "pending_schedule"
+
         # Проверяем, что подписка ещё не началась (для автопродления)
         if current_time < self.start_date:
             return "pending"
@@ -79,6 +85,7 @@ class StudentSubscription(Base):
         now = func.now()
         
         return case(
+            (cls.schedule_confirmed_at.is_(None), "pending_schedule"),
             (now < cls.start_date, "pending"),
             (
                 (cls.freeze_start_date.isnot(None)) &

--- a/app/schemas/student.py
+++ b/app/schemas/student.py
@@ -84,6 +84,7 @@ class StudentResponse(StudentBase):
     active_subscription_id: int | None = None  # ID текущего активного абонемента
     deactivation_date: datetime | None
     has_unpaid_invoice: bool = False  # True если есть UNPAID инвойс
+    trial_used_at: datetime | None = None  # Когда использовал пробное занятие
 
     model_config = {"from_attributes": True}
 

--- a/app/schemas/subscription_v2.py
+++ b/app/schemas/subscription_v2.py
@@ -48,6 +48,7 @@ class StudentSubscriptionResponseV2(BaseModel):
     payment_due_date: Optional[date] = None
     is_prorated: bool = False
     sessions_per_week: Optional[int] = None
+    schedule_confirmed_at: Optional[datetime] = None
 
     # Legacy поля (оставлены для backward compat фронта)
     sessions_left: Optional[int] = None
@@ -100,3 +101,23 @@ class SystemSettingResponse(BaseModel):
 class SystemSettingUpdate(BaseModel):
     key: str = Field(..., description="Ключ настройки")
     value: str = Field(..., description="Новое значение")
+
+
+# ---------------------------------------------------------------------------
+# Training template student add response
+# ---------------------------------------------------------------------------
+
+class TemplateAddStudentResponse(BaseModel):
+    """Ответ при добавлении студента в шаблон.
+
+    subscription_activated=True если это добавление запустило триггер активации абонемента.
+    Фронт показывает toast уведомление если subscription_activated=True.
+    """
+    id: int
+    training_template_id: int
+    student_id: int
+    start_date: date
+    subscription_activated: bool = False
+    subscription_sessions_left_to_add: Optional[int] = None
+
+    model_config = {"from_attributes": True}

--- a/app/services/daily_operations_v2.py
+++ b/app/services/daily_operations_v2.py
@@ -1,7 +1,8 @@
-"""Daily operations v2 — обработка is_subscription_only тренировок."""
+"""Daily operations v2 — обработка всех тренировок (subscription_only + pay-per-session)."""
 import logging
 from datetime import date, datetime, timedelta, timezone
 
+from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
 from app.database import transactional
@@ -11,6 +12,8 @@ from app.models import (
     AttendanceStatus,
     StudentSubscription,
     MissedSession,
+    Invoice,
+    InvoiceStatus,
 )
 from app.models.training_type import TrainingType
 from app.crud.subscription_v2 import (
@@ -18,6 +21,7 @@ from app.crud.subscription_v2 import (
     create_missed_session,
     get_system_setting,
 )
+from app.services.financial import FinancialService
 
 logger = logging.getLogger(__name__)
 
@@ -25,17 +29,21 @@ logger = logging.getLogger(__name__)
 class DailyOperationsServiceV2:
     def __init__(self, db: Session):
         self.db = db
+        self.financial_service = FinancialService(db)
 
     # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
     def process_daily_operations_v2(self) -> dict:
-        """Обрабатывает тренировки прошедшего дня (сегодня ≡ вчера для v2).
+        """Обрабатывает тренировки вчерашнего дня.
 
-        Запускается ежедневно в 01:00 для тренировок текущего дня.
+        - is_subscription_only=True  → создаёт MissedSession при пропусках.
+        - is_subscription_only=False → переводит PENDING инвойсы в UNPAID/CANCELLED.
+
+        Запускается ежедневно в 01:00.
         """
-        processing_date = date.today()
+        processing_date = date.today() - timedelta(days=1)
         logger.info(f"[v2] Processing daily operations for date: {processing_date}")
 
         trainings = (
@@ -44,23 +52,28 @@ class DailyOperationsServiceV2:
             .filter(
                 RealTraining.training_date == processing_date,
                 RealTraining.cancelled_at.is_(None),
-                TrainingType.is_subscription_only == True,
             )
             .all()
         )
 
-        processed = 0
-        skipped = 0
+        subscription_processed = 0
+        subscription_skipped = 0
+        pay_per_session_processed = 0
         errors = 0
 
         for training in trainings:
+            is_sub_only = training.training_type and training.training_type.is_subscription_only
             for student_training in training.students:
                 try:
-                    result = self._process_subscription_user_v2(student_training)
-                    if result == "processed":
-                        processed += 1
+                    if is_sub_only:
+                        result = self._process_subscription_user_v2(student_training)
+                        if result == "processed":
+                            subscription_processed += 1
+                        else:
+                            subscription_skipped += 1
                     else:
-                        skipped += 1
+                        self._process_pay_per_session_user_v2(student_training)
+                        pay_per_session_processed += 1
                 except Exception as e:
                     logger.error(
                         f"[v2] Error processing student_training {student_training.id}: {e}"
@@ -68,12 +81,126 @@ class DailyOperationsServiceV2:
                     errors += 1
 
         self.db.commit()
-        logger.info(f"[v2] Done. processed={processed} skipped={skipped} errors={errors}")
-        return {"processed": processed, "skipped": skipped, "errors": errors}
+        logger.info(
+            f"[v2] Done. subscription_processed={subscription_processed} "
+            f"subscription_skipped={subscription_skipped} "
+            f"pay_per_session_processed={pay_per_session_processed} errors={errors}"
+        )
+        return {
+            "subscription_processed": subscription_processed,
+            "subscription_skipped": subscription_skipped,
+            "pay_per_session_processed": pay_per_session_processed,
+            "errors": errors,
+        }
+
+    def backfill_pending_invoices(self, before_date: date | None = None) -> dict:
+        """Одноразовый бэкфилл: переводит PENDING инвойсы типа TRAINING для уже
+
+        прошедших тренировок (до before_date включительно) в UNPAID или CANCELLED.
+        Идемпотентен — безопасно запускать повторно.
+        """
+        from app.models.invoice import InvoiceType
+
+        if before_date is None:
+            before_date = date.today()
+
+        pending_invoices = (
+            self.db.query(Invoice)
+            .join(RealTraining, Invoice.training_id == RealTraining.id)
+            .filter(
+                Invoice.status == InvoiceStatus.PENDING,
+                Invoice.type == InvoiceType.TRAINING,
+                RealTraining.training_date < before_date,
+            )
+            .all()
+        )
+
+        processed = 0
+        errors = 0
+
+        for invoice in pending_invoices:
+            try:
+                # Найти запись студента на тренировку, чтобы определить финальный статус
+                student_training = (
+                    self.db.query(RealTrainingStudent)
+                    .filter(
+                        RealTrainingStudent.real_training_id == invoice.training_id,
+                        RealTrainingStudent.student_id == invoice.student_id,
+                    )
+                    .first()
+                )
+
+                if student_training and student_training.status == AttendanceStatus.CANCELLED_SAFE:
+                    invoice.status = InvoiceStatus.CANCELLED
+                    self.db.add(invoice)
+                else:
+                    # PRESENT / ABSENT / REGISTERED / CANCELLED_PENALTY / нет записи → UNPAID
+                    invoice.status = InvoiceStatus.UNPAID
+                    self.db.add(invoice)
+                    self.db.flush()
+                    try:
+                        self.financial_service.attempt_auto_payment(self.db, invoice.id)
+                    except Exception:
+                        pass  # Недостаточно баланса — оставить UNPAID, это ок
+
+                processed += 1
+            except Exception as e:
+                logger.error(f"[v2 backfill] Error processing invoice {invoice.id}: {e}")
+                errors += 1
+
+        self.db.commit()
+        logger.info(f"[v2 backfill] Done. processed={processed} errors={errors}")
+        return {"processed": processed, "errors": errors}
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _process_pay_per_session_user_v2(self, student_training: RealTrainingStudent) -> None:
+        """Переводит PENDING training инвойс в UNPAID или CANCELLED.
+
+        Логика:
+        - REGISTERED / PRESENT / ABSENT / CANCELLED_PENALTY → UNPAID → попытка автооплаты.
+        - CANCELLED_SAFE → CANCELLED (безопасная отмена, платить не нужно).
+        - Нет PENDING инвойса → ничего не делаем.
+        """
+        invoice = (
+            self.db.query(Invoice)
+            .filter(
+                Invoice.student_id == student_training.student_id,
+                Invoice.training_id == student_training.real_training_id,
+                Invoice.status == InvoiceStatus.PENDING,
+            )
+            .first()
+        )
+
+        if not invoice:
+            return
+
+        if student_training.status in (
+            AttendanceStatus.REGISTERED,
+            AttendanceStatus.PRESENT,
+            AttendanceStatus.ABSENT,
+            AttendanceStatus.CANCELLED_PENALTY,
+        ):
+            invoice.status = InvoiceStatus.UNPAID
+            self.db.add(invoice)
+            self.db.flush()
+            try:
+                self.financial_service.attempt_auto_payment(self.db, invoice.id)
+            except Exception:
+                pass  # Недостаточно баланса — оставить UNPAID
+            logger.info(
+                f"[v2] Invoice {invoice.id} → UNPAID for student {student_training.student_id} "
+                f"(status={student_training.status})"
+            )
+        elif student_training.status == AttendanceStatus.CANCELLED_SAFE:
+            invoice.status = InvoiceStatus.CANCELLED
+            self.db.add(invoice)
+            logger.info(
+                f"[v2] Invoice {invoice.id} → CANCELLED (CANCELLED_SAFE) "
+                f"for student {student_training.student_id}"
+            )
 
     def _process_subscription_user_v2(self, student_training: RealTrainingStudent) -> str:
         """Обрабатывает одну запись студента на is_subscription_only тренировку (v2).

--- a/app/services/subscription_v2.py
+++ b/app/services/subscription_v2.py
@@ -97,17 +97,16 @@ def add_subscription_to_student_v2(
 ) -> "StudentSubscription":
     """Назначает абонемент студенту (v2 логика).
 
-    start_date = сегодня, end_date = последний день текущего месяца.
-    Пропорциональная цена если purchase_date.day > 1.
-    Создаёт PENDING инвойс, пробует автооплату.
+    Если покупка 1-го числа: сразу создаёт PENDING инвойс, абонемент активен.
+    Если mid-month: абонемент в PENDING_SCHEDULE, инвойс выставится после настройки расписания.
     """
-    from app.database import transactional
     from app.models import StudentSubscription, Subscription
     from app.models.student import Student
     from app.models.invoice import InvoiceStatus, InvoiceType
     from app.schemas.invoice import InvoiceCreate
     from app.crud import subscription as sub_crud
     from app.crud import student as student_crud
+    from app.crud.subscription_v2 import get_pending_schedule_subscription, get_active_or_pending_subscription
     from app.services.financial import FinancialService
     from app.errors.subscription_errors import SubscriptionNotFound, SubscriptionAlreadyActive
 
@@ -123,41 +122,171 @@ def add_subscription_to_student_v2(
     if not student or not student.is_active:
         raise ValueError("Student not found or inactive")
 
-    sessions_per_week = subscription.sessions_per_week or 1
+    # Проверка на дублирующий абонемент
     purchase_date = datetime.now(timezone.utc).date()
+    existing_active = get_active_or_pending_subscription(db, student_id, purchase_date)
+    if existing_active:
+        raise SubscriptionAlreadyActive("Student already has an active subscription")
+    existing_pending_schedule = get_pending_schedule_subscription(db, student_id)
+    if existing_pending_schedule:
+        raise SubscriptionAlreadyActive("Student already has a subscription pending schedule setup")
 
     end_date_d = _get_month_end_date(purchase_date)
     start_dt = datetime(purchase_date.year, purchase_date.month, purchase_date.day, tzinfo=timezone.utc)
     end_dt = datetime(end_date_d.year, end_date_d.month, end_date_d.day, 23, 59, 59, tzinfo=timezone.utc)
 
     if purchase_date.day == 1:
-        is_prorated = False
-        amount = subscription.price
+        # Полный месяц: сразу активируем и выставляем счёт
         payment_due_date = _get_payment_due_date(purchase_date)
+        student_sub = StudentSubscription(
+            student_id=student_id,
+            subscription_id=subscription_id,
+            start_date=start_dt,
+            end_date=end_dt,
+            is_auto_renew=is_auto_renew,
+            is_prorated=False,
+            payment_due_date=payment_due_date,
+            sessions_left=0,
+            schedule_confirmed_at=datetime.now(timezone.utc),
+        )
+        db.add(student_sub)
+        db.flush()
+        db.refresh(student_sub)
+
+        invoice_data = InvoiceCreate(
+            client_id=student.client_id,
+            student_id=student_id,
+            subscription_id=subscription_id,
+            student_subscription_id=student_sub.id,
+            type=InvoiceType.SUBSCRIPTION,
+            amount=subscription.price,
+            description=f"Абонемент: {subscription.name} (v2)",
+            status=InvoiceStatus.PENDING,
+            is_auto_renewal=False,
+        )
+        invoice = financial_service.create_standalone_invoice_in_session(db, invoice_data, auto_pay=True)
+        invoice.due_date = payment_due_date
+        db.flush()
     else:
-        is_prorated = True
-        amount = _calculate_prorated_amount(subscription.price, purchase_date, sessions_per_week)
-        next_month_first = _get_first_of_next_month(purchase_date)
+        # Mid-month: PENDING_SCHEDULE, инвойс выставится после настройки расписания
+        student_sub = StudentSubscription(
+            student_id=student_id,
+            subscription_id=subscription_id,
+            start_date=start_dt,
+            end_date=end_dt,
+            is_auto_renew=is_auto_renew,
+            is_prorated=True,
+            payment_due_date=None,
+            sessions_left=0,
+            schedule_confirmed_at=None,  # PENDING_SCHEDULE
+        )
+        db.add(student_sub)
+        db.flush()
+        db.refresh(student_sub)
+
+    return student_sub
+
+
+def confirm_schedule_and_create_invoice(
+    db: Session,
+    student_subscription_id: int,
+    template_ids: list[int],
+) -> "Invoice":
+    """Триггер: вызывается когда count(шаблоны) == sessions_per_week.
+
+    Считает сессии по дням недели из TrainingStudentTemplate (не зависит от RealTraining).
+
+    Для каждого шаблона студента:
+      - day_of_week = TrainingTemplate.day_number (1=Пн ... 7=Вс)
+      - effective_start = max(today, TrainingStudentTemplate.start_date)
+      - remaining = кол-во вхождений этого дня недели от effective_start до конца месяца
+      - total    = кол-во вхождений этого дня недели за весь месяц
+
+    Если remaining == 0 → сдвигаем на следующий месяц, полная цена.
+    """
+    from app.models import StudentSubscription
+    from app.models.training_template import TrainingStudentTemplate, TrainingTemplate
+    from app.models.invoice import InvoiceStatus, InvoiceType
+    from app.schemas.invoice import InvoiceCreate
+    from app.crud import subscription as sub_crud
+    from app.crud import student as student_crud
+    from app.services.financial import FinancialService
+
+    financial_service = FinancialService(db)
+
+    student_sub = db.query(StudentSubscription).filter(
+        StudentSubscription.id == student_subscription_id
+    ).first()
+    if not student_sub:
+        raise ValueError(f"StudentSubscription {student_subscription_id} not found")
+    if student_sub.schedule_confirmed_at is not None:
+        return None  # идемпотентность
+
+    subscription = sub_crud.get_subscription_by_id(db, student_sub.subscription_id)
+    student = student_crud.get_student_by_id(db, student_sub.student_id)
+
+    today = datetime.now(timezone.utc).date()
+    month_start = today.replace(day=1)
+    month_end = _get_month_end_date(today)
+
+    def _count_weekday_occurrences(day_number: int, start: date, end: date) -> int:
+        """Считает кол-во вхождений дня недели (1=Пн..7=Вс) в диапазоне [start, end]."""
+        if start > end:
+            return 0
+        # isoweekday(): 1=Пн .. 7=Вс — совпадает с day_number
+        days_total = (end - start).days + 1
+        full_weeks, remainder = divmod(days_total, 7)
+        count = full_weeks
+        # start.isoweekday() .. start.isoweekday() + remainder - 1
+        start_dow = start.isoweekday()
+        for offset in range(remainder):
+            if ((start_dow - 1 + offset) % 7) + 1 == day_number:
+                count += 1
+        return count
+
+    # Загружаем студенческие шаблоны по training_template_id
+    student_templates = (
+        db.query(TrainingStudentTemplate, TrainingTemplate)
+        .join(TrainingTemplate, TrainingStudentTemplate.training_template_id == TrainingTemplate.id)
+        .filter(
+            TrainingStudentTemplate.student_id == student_sub.student_id,
+            TrainingStudentTemplate.is_frozen == False,
+            TrainingTemplate.id.in_(template_ids),
+        )
+        .all()
+    )
+
+    total_sessions = 0
+    remaining_sessions = 0
+
+    for tst, tt in student_templates:
+        day_number = tt.day_number  # 1..7
+        # effective start = max(today, шаблон.start_date)
+        effective_start = max(today, tst.start_date)
+        total_sessions += _count_weekday_occurrences(day_number, month_start, month_end)
+        remaining_sessions += _count_weekday_occurrences(day_number, effective_start, month_end)
+
+    if remaining_sessions == 0 or total_sessions == 0:
+        # В этом месяце тренировок уже нет — сдвигаем на следующий
+        next_first = _get_first_of_next_month(today)
+        next_last = _get_month_end_date(next_first)
+        student_sub.start_date = datetime(next_first.year, next_first.month, next_first.day, tzinfo=timezone.utc)
+        student_sub.end_date = datetime(next_last.year, next_last.month, next_last.day, 23, 59, 59, tzinfo=timezone.utc)
+        amount = subscription.price
+        payment_due_date = _get_payment_due_date(next_first)
+    else:
+        amount = round(subscription.price * remaining_sessions / total_sessions, 2)
+        next_month_first = _get_first_of_next_month(today)
         payment_due_date = _get_payment_due_date(next_month_first)
 
-    student_sub = StudentSubscription(
-        student_id=student_id,
-        subscription_id=subscription_id,
-        start_date=start_dt,
-        end_date=end_dt,
-        is_auto_renew=is_auto_renew,
-        is_prorated=is_prorated,
-        payment_due_date=payment_due_date,
-        sessions_left=0,  # v2 не использует sessions_left
-    )
-    db.add(student_sub)
+    student_sub.payment_due_date = payment_due_date
+    student_sub.schedule_confirmed_at = datetime.now(timezone.utc)
     db.flush()
-    db.refresh(student_sub)
 
     invoice_data = InvoiceCreate(
         client_id=student.client_id,
-        student_id=student_id,
-        subscription_id=subscription_id,
+        student_id=student_sub.student_id,
+        subscription_id=student_sub.subscription_id,
         student_subscription_id=student_sub.id,
         type=InvoiceType.SUBSCRIPTION,
         amount=amount,
@@ -169,7 +298,7 @@ def add_subscription_to_student_v2(
     invoice.due_date = payment_due_date
     db.flush()
 
-    return student_sub
+    return invoice
 
 
 def process_auto_renewals_v2(db: Session) -> dict:
@@ -300,16 +429,19 @@ def process_overdue_invoices_v2(db: Session) -> dict:
     paid = 0
     unpaid = 0
     for invoice in overdue:
-        user = user_crud.get_user_by_id(db, invoice.client_id)
-        balance = (user.balance or 0.0) if user else 0.0
-        if user and balance >= invoice.amount:
-            from app.schemas.user import UserUpdate
-            invoice_crud.mark_invoice_as_paid(db, invoice.id)
-            user_crud.update_user(db, user.id, UserUpdate(balance=balance - invoice.amount))
-            paid += 1
-        else:
-            invoice_crud.mark_invoice_as_unpaid(db, invoice.id)
-            unpaid += 1
+        try:
+            user = user_crud.get_user_by_id(db, invoice.client_id)
+            balance = (user.balance or 0.0) if user else 0.0
+            if user and balance >= invoice.amount:
+                from app.schemas.user import UserUpdate
+                invoice_crud.mark_invoice_as_paid(db, invoice.id)
+                user_crud.update_user(db, user.id, UserUpdate(balance=balance - invoice.amount))
+                paid += 1
+            else:
+                invoice_crud.mark_invoice_as_unpaid(db, invoice.id)
+                unpaid += 1
+        except Exception as e:
+            logger.error(f"Error processing overdue invoice {invoice.id}: {e}")
 
     db.commit()
     return {"paid": paid, "unpaid": unpaid}

--- a/docs/business/subscription_v2_business_logic.md
+++ b/docs/business/subscription_v2_business_logic.md
@@ -1,0 +1,225 @@
+# Бизнес-логика абонементов v2
+
+> Зафиксировано: 6 апреля 2026
+
+---
+
+## Принципы
+
+- Работаем **только с v2** — v1 не рассматривается
+- У студента одновременно может быть **только один активный абонемент**
+- Абонемент привязан к **типу тренировки** (`training_type`), а не к конкретному шаблону
+- Стоимость считается по **фактическим занятиям в расписании студента** за месяц
+
+---
+
+## Шаблон абонемента (`Subscription`)
+
+| Поле | Описание |
+|---|---|
+| `name` | Название |
+| `price` | Полная стоимость за "стандартный" месяц |
+| `sessions_per_week` | Количество посещений в неделю — используется для **контроля доступа** и для триггера расчёта цены |
+
+---
+
+## Флоу назначения абонемента студенту
+
+### Шаг 1 — Создание абонемента
+
+```
+POST /v2/subscriptions/student
+
+→ StudentSubscription создаётся со статусом PENDING_SCHEDULE
+→ Инвойс НЕ выставляется
+→ Студент пока НЕ может ходить на тренировки
+```
+
+### Шаг 2 — Добавление в расписание
+
+Администратор добавляет студента в шаблоны тренировок (`TrainingStudentTemplate`) по одному.
+
+**Триггер работает только если абонемент в статусе `PENDING_SCHEDULE`.**  
+Если абонемент уже `ACTIVE` — добавление/удаление из шаблонов не влияет на цену и инвойс. Расписание меняется свободно.
+
+После каждого добавления (при `PENDING_SCHEDULE`) автоматически проверяется:
+
+```
+count(TrainingStudentTemplate WHERE student_id = X)
+    == subscription.sessions_per_week ?
+
+→ НЕТ: ждём (расписание ещё не готово)
+→ ДА:  расписание готово → триггер расчёта
+```
+
+### Шаг 3 — Расчёт цены (триггер)
+
+```
+remaining_sessions = COUNT(RealTraining по всем шаблонам студента
+                            WHERE training_date >= today
+                            AND training_date <= last_day_of_month
+                            AND cancelled_at IS NULL)
+
+total_sessions = COUNT(RealTraining по всем шаблонам студента
+                        WHERE training_date >= first_day_of_month
+                        AND training_date <= last_day_of_month
+                        AND cancelled_at IS NULL)
+
+calculated_price = round(full_price × remaining_sessions / total_sessions)
+```
+
+### Шаг 4 — Выставление инвойса
+
+```
+Invoice(
+    type = SUBSCRIPTION,
+    status = PENDING,
+    amount = calculated_price,
+    due_date = 7-е следующего месяца
+)
+
+StudentSubscription.status → ACTIVE
+Студент может ходить на тренировки
+```
+
+---
+
+## Граничный случай: 0 занятий до конца месяца
+
+Если студента добавили в расписание, но до конца месяца не осталось ни одного занятия (например, добавили 30-го):
+
+```
+start_date = 1-е следующего месяца
+total_sessions = занятия по шаблонам в следующем месяце
+calculated_price = full_price (полный месяц, без пропорций)
+due_date = 7-е следующего месяца
+```
+
+---
+
+## Первое число месяца
+
+Если абонемент оформляется 1-го числа:
+
+```
+remaining_sessions == total_sessions
+calculated_price = full_price
+
+due_date = 7-е текущего месяца
+```
+
+---
+
+## Авторенью (конец месяца)
+
+```
+Условие: is_auto_renew = True AND end_date = сегодня
+
+→ Новый StudentSubscription на следующий месяц
+→ calculated_price = full_price (полный месяц, без пропорций)
+→ Invoice(PENDING, due_date = 7-е следующего месяца)
+→ Студент продолжает ходить по тому же расписанию
+```
+
+---
+
+## Контроль доступа на тренировку
+
+```
+Студент регистрируется на subscription_only тренировку:
+
+1. Есть активный абонемент?
+   → НЕТ → проверяем пробное занятие (см. ниже)
+   → ДА  → продолжаем
+
+2. Не превышен ли недельный лимит? (неделя: Пн–Вс)
+   count(всех subscription_only посещений студента за текущую неделю) < sessions_per_week?
+   → ДА  → допускаем, обычная запись
+   → НЕТ → переходим к шагу 3
+
+3. Есть ли активная отработка?
+   MissedSession WHERE student_id = X
+                 AND is_excused = True
+                 AND made_up_at IS NULL
+                 AND makeup_deadline_date >= today
+   → ДА  → допускаем как отработку (made_up_real_training_student_id проставится после занятия)
+   → НЕТ → 403: "Недельный лимит исчерпан"
+```
+
+---
+
+## Пробные занятия
+
+### Правила
+
+- **1 пробное занятие на студента** — глобально, на всю историю
+- Только для тренировок с `is_subscription_only = True`
+- Пробное **бесплатно**, в инвойс не включается
+
+### Флоу
+
+```
+Студент хочет записаться на subscription_only тренировку, абонемента нет:
+
+→ trial_used_at IS NULL?
+   → ДА  → записываем как TRIAL (is_trial=True, requires_payment=False)
+   → НЕТ → 403: "Необходим абонемент"
+```
+
+### Отмена пробного
+
+| Сценарий | Результат |
+|---|---|
+| Студент отменил заранее (CANCELLED_SAFE) | Пробное **не засчитано** — может использовать снова |
+| Студент не пришёл (ABSENT) | Пробное **засчитано** — прогулял, не возвращаем |
+| Студент пришёл (PRESENT) | Пробное **засчитано** |
+
+### После пробного
+
+```
+После обработки дня (daily ops):
+  RealTrainingStudent.is_trial = True AND status = PRESENT
+  → student.trial_used_at = now
+
+Следующий визит на subscription_only → требует абонемент.
+Никаких зачётов стоимости при покупке абонемента. Пробное было подарком.
+```
+
+---
+
+## Механика пропусков (MissedSession)
+
+Существующая логика остаётся без изменений:
+
+| Статус посещения | Действие |
+|---|---|
+| `CANCELLED_SAFE` | `MissedSession(is_excused=True, deadline=today+N дней)` — студент может отработать |
+| `CANCELLED_PENALTY` | `MissedSession(is_excused=False)` + штраф или инвойс |
+| `ABSENT` | `MissedSession(is_excused=False)` — занятие считается использованным |
+| Отработка | `MissedSession.made_up_at = now`, студенту открывается дополнительный слот сверх лимита |
+
+---
+
+## Статусы StudentSubscription
+
+| Статус | Условие |
+|---|---|
+| `PENDING_SCHEDULE` | Абонемент создан, расписание ещё не заполнено |
+| `PENDING` | `now < start_date` |
+| `ACTIVE` | Расписание готово, инвойс выставлен, идёт месяц |
+| `FROZEN` | Заморожен администратором |
+| `EXPIRED` | `now > end_date` и не продлён |
+
+---
+
+## Изменения в БД (к реализации)
+
+```sql
+-- Экземпляр абонемента: рассчитанная цена и статус расписания
+ALTER TABLE student_subscriptions ADD COLUMN calculated_price FLOAT;
+ALTER TABLE student_subscriptions ADD COLUMN schedule_confirmed_at TIMESTAMPTZ;
+
+-- Студент: история пробного занятия
+ALTER TABLE students ADD COLUMN trial_used_at TIMESTAMPTZ;
+ALTER TABLE students ADD COLUMN trial_real_training_student_id INT REFERENCES real_training_students(id);
+```

--- a/docs/technical/implementation_plan_subscription_v2.md
+++ b/docs/technical/implementation_plan_subscription_v2.md
@@ -1,0 +1,272 @@
+# План имплементации — Абонементы v2
+
+> Дата: 6 апреля 2026  
+> Статус: в работе
+
+---
+
+## Бэкенд
+
+### 1. Alembic миграция
+
+Новые поля:
+
+```sql
+-- StudentSubscription: когда расписание было подтверждено (NULL = PENDING_SCHEDULE)
+ALTER TABLE student_subscriptions ADD COLUMN schedule_confirmed_at TIMESTAMPTZ;
+
+-- Student: информация о пробном занятии
+ALTER TABLE students ADD COLUMN trial_used_at TIMESTAMPTZ;
+ALTER TABLE students ADD COLUMN trial_real_training_student_id INT REFERENCES real_training_students(id);
+```
+
+Команда генерации:
+```bash
+alembic revision --autogenerate -m "add_schedule_confirmed_and_trial_fields"
+```
+
+---
+
+### 2. Модели (`app/models/`)
+
+#### `subscription.py` → `StudentSubscription`
+- Добавить `schedule_confirmed_at = Column(DateTime(timezone=True), nullable=True)`
+- Обновить `status` hybrid_property:
+  ```python
+  # Новый статус: если schedule_confirmed_at IS NULL → "pending_schedule"
+  # Иначе — существующая логика (pending/frozen/expired/active)
+  ```
+
+#### `student.py` → `Student`
+- Добавить `trial_used_at = Column(DateTime(timezone=True), nullable=True)`
+- Добавить `trial_real_training_student_id = Column(Integer, ForeignKey("real_training_students.id"), nullable=True)`
+
+---
+
+### 3. CRUD (`app/crud/subscription_v2.py`)
+
+#### `get_active_or_pending_subscription`
+- Добавить исключение `PENDING_SCHEDULE` из результатов — студент с pending_schedule абонементом не должен быть допущен на тренировки.
+
+#### `count_subscription_only_visits`
+- Убрать фильтр по `training_type_id` — считаем ВСЕ subscription_only посещения студента за неделю.
+
+#### Новая функция: `count_student_active_templates`
+```python
+def count_student_active_templates(db, student_id) -> int:
+    """Считает количество активных TrainingStudentTemplate для студента."""
+```
+
+---
+
+### 4. Сервис (`app/services/subscription_v2.py`)
+
+#### `add_subscription_to_student_v2` — ключевые изменения:
+
+**ДО:**
+```
+Создать StudentSubscription → рассчитать цену → создать Invoice → ACTIVE
+```
+
+**ПОСЛЕ:**
+```
+Если покупка 1-го числа:
+  → StudentSubscription(schedule_confirmed_at=now)  # сразу активен
+  → Invoice(PENDING, full_price, due_date=7-е)
+  
+Если покупка в середине месяца:
+  → StudentSubscription(schedule_confirmed_at=NULL)  # PENDING_SCHEDULE
+  → Инвойс НЕ создаётся
+```
+
+**Добавить:**
+- Проверку на дублирующий активный абонемент (`SubscriptionAlreadyActive`)
+
+#### Новая функция: `confirm_schedule_and_create_invoice`
+```python
+def confirm_schedule_and_create_invoice(db, student_subscription_id, template_ids) -> Invoice:
+    """
+    Вызывается когда count(templates) == sessions_per_week.
+    
+    1. Считает remaining_sessions и total_sessions по переданным template_ids
+    2. calculated_price = full_price * remaining / total
+    3. Если remaining == 0: start_date = 1-е следующего месяца, цена = full_price
+    4. Создаёт Invoice(PENDING, calculated_price, due_date=7-е следующего месяца)
+    5. Устанавливает schedule_confirmed_at = now
+    6. Пробует автооплату из баланса
+    """
+```
+
+---
+
+### 5. CRUD training_template (`app/crud/training_template.py`)
+
+#### `create_training_student_template` — добавить триггер:
+
+```python
+# После успешного создания TrainingStudentTemplate:
+
+# Проверяем: есть ли у студента PENDING_SCHEDULE абонемент?
+pending_sub = get_pending_schedule_subscription(db, student_id)
+if pending_sub:
+    sessions_per_week = pending_sub.subscription.sessions_per_week
+    template_count = count_student_active_templates(db, student_id)
+    
+    if template_count >= sessions_per_week:
+        # Собираем все template_ids студента
+        template_ids = get_student_template_ids(db, student_id)
+        # Триггер: выставить инвойс и активировать абонемент
+        confirm_schedule_and_create_invoice(db, pending_sub.id, template_ids)
+```
+
+**Важно:** триггер срабатывает ТОЛЬКО если статус `PENDING_SCHEDULE` (`schedule_confirmed_at IS NULL`).
+
+---
+
+### 6. Валидатор (`app/validators/subscription_validators_v2.py`)
+
+#### `validate_subscription_for_training_v2`
+- `get_active_or_pending_subscription` теперь возвращает только `ACTIVE` (не `pending_schedule`) — логика уже корректна после изменения CRUD
+- Убрать мёртвый параметр `training_is_subscription_only` — early exit из шага 3 убрать, теперь лимит проверяем всегда для subscription_only
+
+#### Обновить `count_subscription_only_visits`
+- Считать все subscription_only тренировки студента за неделю (без фильтра по типу)
+
+---
+
+### 7. Схемы (`app/schemas/subscription_v2.py`)
+
+#### `StudentSubscriptionResponseV2` — добавить:
+```python
+schedule_confirmed_at: Optional[datetime] = None
+trial_used_at: Optional[datetime] = None  # из student (для карточки)
+```
+
+#### Новый ответ при добавлении в шаблон:
+```python
+class TemplateAddStudentResponse(BaseModel):
+    student_template: TrainingStudentTemplateResponse
+    subscription_activated: bool
+    invoice: Optional[InvoiceResponse] = None
+    # Если True — фронт показывает toast "Абонемент активирован"
+```
+
+---
+
+### 8. Эндпоинты (`app/endpoints/subscriptions_v2.py`)
+
+Без новых эндпоинтов.  
+Результат триггера возвращается через ответ `POST /training_student_templates/`.
+
+---
+
+### 9. Баги которые фиксим попутно
+
+| Файл | Проблема | Фикс |
+|---|---|---|
+| `services/daily_operations_v2.py` | `processing_date = date.today()` | `date.today() - timedelta(days=1)` |
+| `services/subscription_v2.py` | Нет проверки на дублирующий абонемент | Добавить guard перед созданием |
+| `services/subscription_v2.py` | `process_overdue_invoices_v2` нет per-item try/except | Обернуть каждый инвойс |
+
+---
+
+## Фронтенд
+
+### 1. RTK Query API
+
+#### `calendarApi-v2.ts`
+- Обновить тип ответа `createTrainingStudentTemplate` → `TemplateAddStudentResponse`
+- При `subscription_activated: true` → инвалидировать тег `Student` (обновить карточку)
+
+#### `studentsApi.ts` (или аналог)
+- `StudentSubscription` тип — добавить `schedule_confirmed_at`
+
+---
+
+### 2. `TrainingTemplateModal.tsx`
+
+После добавления студента (`handleAddStudent`):
+- Проверить ответ на `subscription_activated: true` → показать toast
+- Если у добавляемого студента есть `pending_schedule` абонемент → показать подсказку в форме:
+  ```
+  🟡 Ожидает расписания: N из M дней добавлено
+  После добавления этого слота счёт выставится автоматически.
+  ```
+
+**Как получить статус абонемента студента в модалке:**
+- При открытии формы добавления → запросить `GET /v2/subscriptions/student/{student_id}`
+- Найти абонемент с `schedule_confirmed_at == null`
+
+---
+
+### 3. `AddSubscriptionForm.tsx` (карточка студента)
+
+**Убрать:**
+- Логику предпросмотра цены с пропорцией по дням
+
+**Добавить:**
+- Информационный блок: _"Счёт будет выставлен автоматически после настройки расписания в календаре"_
+- Исключение: если сегодня 1-е → показать сумму сразу
+
+---
+
+### 4. `StudentActiveSubscriptionCard.tsx`
+
+**Новый статус `pending_schedule`:**
+```
+🟡 Ожидает расписания
+   Добавлено: N из M дней
+   [ Открыть календарь → ]
+```
+
+Прогресс `N` получаем из `GET /v2/subscriptions/student/{id}` или через отдельный счётчик шаблонов.
+
+---
+
+### 5. `RealTrainingModal.tsx` — секция добавления студента
+
+**Новая логика при выборе студента:**
+
+```
+GET /v2/subscriptions/student/{student_id} → есть активный абонемент?
+
+ДА + недельный лимит не превышен:
+  → обычная кнопка [Добавить]
+
+НЕТ + trial не использован (trial_used_at = null):
+  → 💡 "Записать как пробное занятие (бесплатно, 1 раз)"
+  → radio: ○ Обычная ● Пробное
+  → [Добавить]
+
+НЕТ + trial использован:
+  → ⚠️ "Пробное использовано. Необходим абонемент."
+  → кнопка [Добавить] заблокирована
+
+ACTIVE абонемент + лимит исчерпан:
+  → ⚠️ "Недельный лимит исчерпан (N из N)"
+  → кнопка заблокирована (или разблокирована если есть makeup)
+```
+
+**Для проверки trial:** данные `trial_used_at` получаем из ответа `GET /v2/subscriptions/student/{student_id}` (добавить в ответ).
+
+---
+
+## Порядок выполнения
+
+```
+[x] Бизнес-логика задокументирована
+[ ] 1. Alembic миграция
+[ ] 2. Модели
+[ ] 3. CRUD subscription_v2
+[ ] 4. Сервис subscription_v2
+[ ] 5. CRUD training_template (триггер)
+[ ] 6. Валидатор
+[ ] 7. Схемы
+[ ] 8. Баги (daily_ops, duplicate guard, overdue per-item)
+--- проверка: alembic upgrade head + запуск тестов ---
+[ ] 9. Фронтенд: RTK Query типы
+[ ] 10. Фронтенд: TrainingTemplateModal
+[ ] 11. Фронтенд: AddSubscriptionForm
+[ ] 12. Фронтенд: StudentActiveSubscriptionCard
+[ ] 13. Фронтенд: RealTrainingModal
+```


### PR DESCRIPTION
…ops v2 enhancements

- Add schedule_confirmed_at to StudentSubscription, trial_used_at and trial_real_training_student_id to Student
- Migration: 307c1eed5b0c_add_schedule_confirmed_and_trial_fields
- Rewrite confirm_schedule_and_create_invoice to use weekday-occurrence counting from template data (no RealTraining dependency)
- Fix SQLAlchemy FK ambiguity on RealTrainingStudent.student and Student.real_trainings
- Add pending_schedule → active flow: invoice created after all templates confirmed
- DailyOperationsServiceV2: process both is_subscription_only and pay-per-session trainings
- Add backfill_pending_invoices method and POST /v2/cron/backfill-pending-invoices endpoint
- Add trial_used_at to StudentResponse schema
- Add subscription_activated flag to TrainingStudentTemplate endpoint response