### PR TITLE
feat: update real training creation to support is_trial per student

### DIFF
--- a/app/endpoints/real_trainings.py
+++ b/app/endpoints/real_trainings.py
@@ -117,8 +117,8 @@ def create_training_endpoint(
     """
     service = RealTrainingService(db)
     try:
-        if training_data.trial_student_id:
-            return service.create_real_training_with_trial_student(training_data)
+        if training_data.student_id:
+            return service.create_real_training_with_student(training_data)
         else:
             return create_real_training(db, training_data)
     except Exception as e:

--- a/app/schemas/real_training.py
+++ b/app/schemas/real_training.py
@@ -35,6 +35,8 @@ class RealTrainingCreate(BaseModel):
     responsible_trainer_id: int
     training_type_id: int
     template_id: Optional[int] = None
+    student_id: Optional[int] = None
+    is_trial: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/services/real_training.py
+++ b/app/services/real_training.py
@@ -119,21 +119,21 @@ class RealTrainingService:
         with transactional(self.db) as session:
             return self._update_student_attendance_logic(session, training_id, student_id, update_data, marker_id)
 
-    def create_real_training_with_trial_student(
+    def create_real_training_with_student(
         self,
-        training_data: RealTrainingWithTrialStudentCreate,
+        training_data: RealTrainingCreate,
     ) -> RealTraining:
         """
-        Создает новую тренировку с одним пробным студентом.
+        Создает новую тренировку с одним студентом (пробный или обычный).
         """
         with transactional(self.db) as session:
             # Create the real training
             db_training = crud.create_real_training(session, training_data)
 
-            # Add the trial student
+            # Add the student
             student_data = RealTrainingStudentCreate(
                 student_id=training_data.student_id,
-                is_trial=True
+                is_trial=training_data.is_trial
             )
             self._add_student_to_training_logic(session, db_training.id, student_data)
 


### PR DESCRIPTION
- RealTrainingCreate schema: added student_id and is_trial fields
- real_training service: renamed to create_real_training_with_student, uses is_trial from data
- real_trainings endpoint: check student_id instead of trial_student_id